### PR TITLE
Remove wrong default statement in the argparser

### DIFF
--- a/nextcloud_news_updater/common/argumentparser.py
+++ b/nextcloud_news_updater/common/argumentparser.py
@@ -62,7 +62,7 @@ class ArgumentParser:
         self.parser.add_argument('--php',
                                  help='Path to the PHP binary, '
                                       'e.g. /usr/bin/php7.0, defaults to '
-                                      'php', default='php')
+                                      'php')
         self.parser.add_argument('url',
                                  help='The URL or absolute path to the '
                                       'directory where Nextcloud is installed.'


### PR DESCRIPTION
Without this commit the argumentparser always puts a default of 'php' for the key 'php' and by that overwrites whatever is coming from the config file.

Fixes #11