### PR TITLE
Add support for Nextcloud News v15

### DIFF
--- a/nextcloud_news_updater/api/api.py
+++ b/nextcloud_news_updater/api/api.py
@@ -13,17 +13,26 @@ class Feed:
 
 
 class Api:
-    def parse_feed(self, json_string: str) -> List[Feed]:
-        """
-        Wrapper around json.loads for better error messages
-        """
+    """API JSON results parser"""
+
+    def parse_users(self, json_str: str) -> List[str]:
+        """Returns a list of userIDs from JSON data"""
         try:
-            feed_json = json.loads(json_string)
-            return self._parse_json(feed_json)
+            users_dict = json.loads(json_str)
+            return list(users_dict.keys())
         except ValueError:
-            msg = "Could not parse given JSON: %s" % json_string
+            msg = 'Could not parse the JSON user list: %s' % json_str
             raise ValueError(msg)
 
-    def _parse_json(self, feed_json: Any) -> List[Feed]:
-        feed_json = feed_json['feeds']
-        return [Feed(info['id'], info['userId']) for info in feed_json]
+    def parse_feeds(self, json_str: str, userID: str = None) -> List[Feed]:
+        """Returns a list of feeds from JSON data"""
+        try:
+            feeds_json = json.loads(json_str)
+            return self._parse_feeds_json(feeds_json, userID)
+        except ValueError:
+            msg = 'Could not parse given JSON: %s' % json_str
+            raise ValueError(msg)
+
+    def _parse_feeds_json(self, feeds: dict, userID: str) -> List[Feed]:
+        feeds = feeds['feeds']
+        return [Feed(info['id'], info['userId']) for info in feeds]

--- a/nextcloud_news_updater/api/cli.py
+++ b/nextcloud_news_updater/api/cli.py
@@ -21,14 +21,16 @@ class CliApi(Api):
         if not directory.endswith('/'):
             directory += '/'
         self.directory = directory
-        base_command = [config.php, '-f', self.directory + 'occ']
+        self.base_command = [config.php, '-f', self.directory + 'occ']
         if phpini is not None and phpini.strip() != '':
-            base_command += ['-c', phpini]
-        self.before_cleanup_command = base_command + [
+            self.base_command += ['-c', phpini]
+        self.before_cleanup_command = self.base_command + [
             'news:updater:before-update']
-        self.all_feeds_command = base_command + ['news:updater:all-feeds']
-        self.update_feed_command = base_command + ['news:updater:update-feed']
-        self.after_cleanup_command = base_command + [
+        self.all_feeds_command = self.base_command + [
+            'news:updater:all-feeds']
+        self.update_feed_command = self.base_command + [
+            'news:updater:update-feed']
+        self.after_cleanup_command = self.base_command + [
             'news:updater:after-update']
 
 
@@ -40,11 +42,28 @@ class CliApiV2(CliApi):
         return [Feed(info['feedId'], info['userId']) for info in feeds]
 
 
+class CliApiV15(CliApi):
+    """Cli API for Nextcloud News v15+"""
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config)
+        self.all_feeds_command = self.base_command + ['news:feed:list']
+        self.users_list_command = self.base_command + ['user:list', '--output',
+                                                       'json']
+
+    def _parse_feeds_json(self, feeds_json: Any, userID: str) -> List[Feed]:
+        if not feeds_json:
+            return []
+        return [Feed(info['id'], userID) for info in feeds_json]
+
+
 def create_cli_api(config: Config) -> CliApi:
     if config.apilevel == 'v1-2':
         return CliApi(config)
     if config.apilevel == 'v2':
         return CliApiV2(config)
+    if config.apilevel == 'v15':
+        return CliApiV15(config)
 
 
 class CliUpdateThread(UpdateThread):
@@ -57,6 +76,16 @@ class CliUpdateThread(UpdateThread):
     def update_feed(self, feed: Feed) -> None:
         command = self.api.update_feed_command + [str(feed.feed_id),
                                                   feed.user_id]
+        self.logger.info('Running update command: %s' % ' '.join(command))
+        self.cli.run(command)
+
+
+class CliUpdateThreadV15(CliUpdateThread):
+    """Cli Updater for Nextcloud News v15+"""
+
+    def update_feed(self, feed: Feed) -> None:
+        command = self.api.update_feed_command + [feed.user_id,
+                                                  str(feed.feed_id)]
         self.logger.info('Running update command: %s' % ' '.join(command))
         self.cli.run(command)
 
@@ -88,3 +117,30 @@ class CliUpdater(Updater):
         self.logger.info('Running after update command: %s' %
                          ' '.join(self.api.after_cleanup_command))
         self.cli.run(self.api.after_cleanup_command)
+
+
+class CliUpdaterV15(CliUpdater):
+    """Cli Updater for Nextcloud News v15+"""
+
+    def start_update_thread(self, feeds: List[Feed]) -> CliUpdateThread:
+        return CliUpdateThreadV15(feeds, self.logger, self.api, self.cli)
+
+    def all_feeds(self) -> List[Feed]:
+        self.logger.info('Running get user list command: %s' %
+                         ' '.join(self.api.users_list_command))
+        users_json = self.cli.run(self.api.users_list_command).strip()
+        users_json = str(users_json, 'utf-8')
+        users = self.api.parse_users(users_json)
+
+        feeds_list = []
+        for userID in users:
+            self.logger.info('Running get feeds for user "%s" command: %s' %
+                             (userID, ' '.join(self.api.all_feeds_command)))
+            cmd = self.api.all_feeds_command + [userID]
+            feeds_json_bytes = self.cli.run(cmd).strip()
+            feeds_json = str(feeds_json_bytes, 'utf-8')
+            self.logger.info('Received these feeds to update for user %s: %s' %
+                             (userID, feeds_json))
+            feeds_list += self.api.parse_feeds(feeds_json, userID)
+
+        return feeds_list

--- a/nextcloud_news_updater/api/cli.py
+++ b/nextcloud_news_updater/api/cli.py
@@ -13,6 +13,8 @@ class Cli:
 
 
 class CliApi(Api):
+    """Cli API for Nextcloud News up to v14 (API version 1.2)"""
+
     def __init__(self, config: Config) -> None:
         directory = config.url
         phpini = config.phpini
@@ -31,12 +33,11 @@ class CliApi(Api):
 
 
 class CliApiV2(CliApi):
-    def __init__(self, config: Config) -> None:
-        super().__init__(config)
+    """Cli API for Nextcloud News up to v14 (API version 2)"""
 
-    def _parse_json(self, feed_json: Any) -> List[Feed]:
-        feed_json = feed_json['updater']
-        return [Feed(info['feedId'], info['userId']) for info in feed_json]
+    def _parse_feeds_json(self, feeds: dict, userID: str) -> List[Feed]:
+        feeds = feeds['updater']
+        return [Feed(info['feedId'], info['userId']) for info in feeds]
 
 
 def create_cli_api(config: Config) -> CliApi:
@@ -81,7 +82,7 @@ class CliUpdater(Updater):
         self.logger.info('Running get all feeds command: %s' %
                          ' '.join(self.api.all_feeds_command))
         self.logger.info('Received these feeds to update: %s' % feeds_json)
-        return self.api.parse_feed(feeds_json)
+        return self.api.parse_feeds(feeds_json)
 
     def after_update(self) -> None:
         self.logger.info('Running after update command: %s' %

--- a/nextcloud_news_updater/api/web.py
+++ b/nextcloud_news_updater/api/web.py
@@ -36,9 +36,9 @@ class WebApiV2(WebApi):
         self.all_feeds_url = '%s/updater/all-feeds' % self.base_url
         self.update_url = '%s/updater/update-feed' % self.base_url
 
-    def _parse_json(self, feed_json: Any) -> List[Feed]:
-        feed_json = feed_json['updater']
-        return [Feed(info['feedId'], info['userId']) for info in feed_json]
+    def _parse_feeds_json(self, feeds: dict, userID: str) -> List[Feed]:
+        feeds = feeds['updater']
+        return [Feed(info['feedId'], info['userId']) for info in feeds]
 
 
 def create_web_api(config: Config) -> WebApi:
@@ -82,7 +82,7 @@ class WebUpdater(Updater):
     def all_feeds(self) -> List[Feed]:
         feeds_json = self.client.get(self.api.all_feeds_url, self.auth)
         self.logger.info('Received these feeds to update: %s' % feeds_json)
-        return self.api.parse_feed(feeds_json)
+        return self.api.parse_feeds(feeds_json)
 
     def after_update(self) -> None:
         self.logger.info(

--- a/nextcloud_news_updater/config.py
+++ b/nextcloud_news_updater/config.py
@@ -74,7 +74,7 @@ class ConfigValidator:
             result += ['Unknown mode: %s' % config.mode]
         if config.loglevel not in ['info', 'error']:
             result += ['Unknown loglevel: %s' % config.loglevel]
-        if config.apilevel not in ['v1-2', 'v2']:
+        if config.apilevel not in ['v1-2', 'v2', 'v15']:
             result += ['Unknown apilevel: %s' % config.apilevel]
 
         if config.phpini and not os.path.isabs(config.phpini):

--- a/nextcloud_news_updater/container.py
+++ b/nextcloud_news_updater/container.py
@@ -1,6 +1,6 @@
 import sys
 
-from nextcloud_news_updater.api.cli import CliUpdater, CliApi, \
+from nextcloud_news_updater.api.cli import CliUpdater, CliUpdaterV15, CliApi, \
     create_cli_api
 from nextcloud_news_updater.api.updater import Updater
 from nextcloud_news_updater.api.web import create_web_api, WebApi, \
@@ -23,6 +23,8 @@ class Container(BaseContainer):
     def _create_updater(self, container: BaseContainer) -> Updater:
         if container.resolve(Config).is_web():
             return container.resolve(WebUpdater)
+        elif container.resolve(Config).apilevel == 'v15':
+            return container.resolve(CliUpdaterV15)
         else:
             return container.resolve(CliUpdater)
 


### PR DESCRIPTION
This adds support for Nextcloud news v15 but only in cli mode (not in the web mode).
At the moment you need to set `apilevel = v15` to work with the new API.

Actually, I don't like that much the idea of using the version of the APP to identify the version of the API; any suggestion?