### PR TITLE
Exclude tests from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     author='Bernhard Posselt',
     author_email='dev@bernhard-posselt.com',
     url='https://github.com/nextcloud/news-updater',
-    packages=find_packages(),
+    packages=find_packages(
+        exclude=['tests', 'tests.*'],
+    ),
     include_package_data=True,
     license='GPL',
     keywords=['nextcloud', 'news', 'updater', 'RSS', 'Atom', 'feed', 'reader'],


### PR DESCRIPTION
setup.py:
Add the `exclude` parameter to `find_packages()` to exclude the `tests/`
directory and its subdirectories.
The `tests/` directory would otherwise be installed top-level to site-packages
and conflict with other packages with the same defect.

Fixes #30